### PR TITLE
feat: snapshot payout currency

### DIFF
--- a/doc/data.md
+++ b/doc/data.md
@@ -185,6 +185,7 @@ model LongTermCashPayout {
   planId    String
   payDate   DateTime
   amount    Decimal
+  currency  String   @default("CNY") // 生成时写入 plan.currency，避免计划币种变更影响已生成记录
   createdAt DateTime @default(now())
 
   plan      LongTermCashPlan @relation(fields: [planId], references: [id])


### PR DESCRIPTION
## Summary
- capture plan currency on LongTermCashPayout to avoid later plan changes affecting existing payouts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: configuration and at-rule issues)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8300420483228333d1008aa838bb