### PR TITLE
docs: capture income source currency

### DIFF
--- a/doc/data.md
+++ b/doc/data.md
@@ -197,6 +197,8 @@ model IncomeRecord {
   monthDate           DateTime // 当月第一天
   cityId              String?
   currency            String   @default("CNY")
+  sourceCurrency      String?          // 原始币种
+  fxRateId            String?          // 汇率快照ID
 
   // 来自工资/奖金/长期现金等的“毛收入”组成
   gross               Decimal              // 月薪（从 IncomeChange 推）
@@ -225,6 +227,7 @@ model IncomeRecord {
 
   user                User     @relation(fields: [userId], references: [id])
   city                City?    @relation(fields: [cityId], references: [id])
+  fxRate              FxRate?  @relation(fields: [fxRateId], references: [id])
 
   @@unique([userId, monthDate])
   @@index([userId, monthDate])
@@ -553,6 +556,8 @@ async function seed() {
       await prisma.incomeRecord.upsert({
         where: { userId_monthDate: { userId: user.id, monthDate: d } },
         update: {
+          sourceCurrency: "CNY",
+          fxRateId: null,
           gross,
           bonus,
           otherIncome: ltc,
@@ -564,6 +569,8 @@ async function seed() {
           monthDate: d,
           cityId: hz.id,
           currency: "CNY",
+          sourceCurrency: "CNY",
+          fxRateId: null,
           gross,
           bonus,
           otherIncome: ltc,


### PR DESCRIPTION
## Summary
- document sourceCurrency and fxRateId fields on IncomeRecord
- explain recording income in original currency and converting via FX rate

## Testing
- `npm run lint` *(fails: unknown at-rules and formatting issues)*

------
https://chatgpt.com/codex/tasks/task_e_68aa82d6838c83228170bd5a271e6fdd