### PR TITLE
docs: document bonus tax method

### DIFF
--- a/doc/data.md
+++ b/doc/data.md
@@ -156,12 +156,14 @@ model BonusPlan {
   userId        String
   amount        Decimal
   currency      String   @default("CNY")
+  taxMethod     String   @default("MERGE") // MERGE: 并入工资综合计税; SEPARATE: 单独计税
   effectiveDate DateTime
   createdAt     DateTime @default(now())
 
   user          User     @relation(fields: [userId], references: [id])
 
   @@index([userId, effectiveDate])
+  @@check(taxMethod IN ("MERGE", "SEPARATE"))
 }
 
 model LongTermCashPlan {

--- a/doc/tech.md
+++ b/doc/tech.md
@@ -193,6 +193,7 @@
 #### 奖金计划（一次性）
 
 - `POST /income/bonus-plans`
+  - `taxMethod`: `MERGE`（并入工资综合计税）或 `SEPARATE`（单独计税），默认 `MERGE`
 
   ```json
   {


### PR DESCRIPTION
## Summary
- clarify `taxMethod` values for bonus plan API
- add `taxMethod` field to `BonusPlan` table design with default and validation

## Testing
- `pnpm lint` *(fails: unknown CSS at-rules and config version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68aa82c47c188322b1183801eb92f278